### PR TITLE
Rest api client and friends

### DIFF
--- a/src/Northstar.js
+++ b/src/Northstar.js
@@ -2,7 +2,7 @@ import RestApiClient from './RestApiClient';
 
 class PhoenixAshes extends RestApiClient {
   constructor(config = {}, overrides = {}) {
-    const baseUrl = 'https://staging.dosomething.org';
+    const baseUrl = 'https://northstar-qa.dosomething.org';
 
     super(baseUrl, {
       credentials: 'omit',

--- a/src/Phoenix.js
+++ b/src/Phoenix.js
@@ -1,0 +1,17 @@
+import RestApiClient from './RestApiClient';
+
+class Phoenix extends RestApiClient {
+  constructor(config = {}, overrides = {}) {
+    super();
+  }
+
+  getAllReportbacks() {
+    // add code to request all reportbacks for a campaign
+  }
+
+  getReportback() {
+    // add code to request a specific reportback
+  }
+}
+
+export default Phoenix;

--- a/src/RestApiClient.js
+++ b/src/RestApiClient.js
@@ -46,6 +46,18 @@ class RestApiClient {
   }
 
   /**
+   * Send a DELETE request to the given path URI.
+   *
+   * @param  {String} path
+   * @return {Object}
+   */
+  delete(path) {
+    const url = `${this.url}/${path}`;
+
+    return this.send('DELETE', url);
+  }
+
+  /**
    * Get the CSRF token if present as a meta tag in the document.
    *
    * @return {String|null}

--- a/src/RestApiClient.js
+++ b/src/RestApiClient.js
@@ -9,20 +9,40 @@ class RestApiClient {
       this.url = url;
     }
 
-    this.options = {
+    this.config = {
       headers: {
         'Content-Type': 'application/json',
         'Accept': 'application/json',
       },
+      credentials: overrides.credentials || 'same-origin',
     };
 
     const csrfToken = this.getCsrfToken();
 
     if (csrfToken) {
-      this.options.headers['X-CSRF-Token'] = csrfToken;
+      this.config.headers['X-CSRF-Token'] = csrfToken;
     }
 
-    merge(this.options, overrides);
+    merge(this.config, overrides);
+  }
+
+  /**
+   * Check the HTTP status of API response.
+   *
+   * @param  {Object} response
+   * @return {Object}
+   * @throws {Object}
+   */
+  checkStatus(response) {
+    if (response.status >= 200 && response.status < 300) {
+      return response;
+    } else {
+      const error = new Error(response.statusText);
+
+      error.response = response;
+
+      throw error;
+    }
   }
 
   /**
@@ -43,6 +63,103 @@ class RestApiClient {
    */
   getLocalUrl() {
     return `//${window.location.hostname}${window.location.port}`;
+  }
+
+  /**
+   * Send a GET request to the given path URI.
+   *
+   * @param  {String} path
+   * @param  {Object} query
+   * @return {Object}
+   */
+  get(path, query = {}) {
+    const url = `${this.url}/${path}${this.stringifyQuery(query)}`;
+
+    console.log(url);
+
+    return this.send('GET', url);
+  }
+
+  /**
+   * Return the JSON data from API response.
+   *
+   * @param  {Object} response
+   * @return {Object}
+   */
+  parseJson(response) {
+    return response.json();
+  }
+
+  /**
+   * Send a POST request to the given path URI.
+   *
+   * @param  {String} path
+   * @param  {Object} body
+   * @param  {Object} headers
+   * @return {Object}
+   */
+  post(path, body = {}) {
+    const url = `${this.url}/${path}`;
+
+    console.log(url, body);
+
+    // return this.send('POST', url, {
+    //   body: JSON.stringify(body)
+    // });
+  }
+
+  /**
+   * Convert object with query parameters into string.
+   *
+   * @param  {Object} query
+   * @return {String}
+   */
+  stringifyQuery(query = {}) {
+    let urlParams = [];
+
+    Object.keys(query).forEach((key) => {
+      urlParams.push(`${encodeURIComponent(key)}=${encodeURIComponent(query[key])}`);
+    });
+
+    if (urlParams.length === 0) {
+      return '';
+    }
+
+    return `?${urlParams.join('&')}`;
+  }
+
+  /**
+   * Send an API request using fetch() and return response.
+   *
+   * @param  {String} method
+   * @param  {String} url
+   * @param  {Object} data
+   * @return {Promise}
+   */
+  send(method, url, data = {}) {
+    const options = {
+      method: method,
+      headers: this.config.headers,
+      credentials: this.config.credentials,
+    };
+
+    merge(options, data);
+
+    // Developer Output:
+    console.log('%c API Client %s Request:',
+      'background-color: rgba(105,157,215,0.5); color: rgba(33,70,112,1); display: block; font-weight: bold; line-height: 1.5;',
+      method
+    );
+    console.log('URL: \n%s', url);
+    console.log('Options: \n%o', options);
+
+    return window.fetch(url, options)
+      .then(this.checkStatus)
+      .then(this.parseJson)
+      .catch((data) => {
+        console.log(data);
+        console.error('um, there was an error! handle that shizzzzz!');
+      });
   }
 }
 

--- a/src/RestApiClient.js
+++ b/src/RestApiClient.js
@@ -75,8 +75,6 @@ class RestApiClient {
   get(path, query = {}) {
     const url = `${this.url}/${path}${this.stringifyQuery(query)}`;
 
-    console.log(url);
-
     return this.send('GET', url);
   }
 
@@ -101,11 +99,9 @@ class RestApiClient {
   post(path, body = {}) {
     const url = `${this.url}/${path}`;
 
-    console.log(url, body);
-
-    // return this.send('POST', url, {
-    //   body: JSON.stringify(body)
-    // });
+    return this.send('POST', url, {
+      body: JSON.stringify(body)
+    });
   }
 
   /**

--- a/src/gateway.js
+++ b/src/gateway.js
@@ -1,5 +1,11 @@
 import RestApiClient from './RestApiClient';
 import PhoenixAshes from './PhoenixAshes';
+import Phoenix from './Phoenix';
+import Northstar from './Northstar';
 
-
-export { RestApiClient, PhoenixAshes }
+export {
+  RestApiClient,
+  PhoenixAshes,
+  Phoenix,
+  Northstar,
+}


### PR DESCRIPTION
This PR expands on the `RestApiClient` to add some of the additional methods for making requests to API services. It also adds a couple modules that can extend the main `RestApiClient` that can be expanded on the provide more useful and specific methods that apply to that particular service.

The following is an example so far of how this can be used in a DoSomething project:

```javascript
import { Phoenix } from '@dosomething/gateway';

const client = new Phoenix();

client.get('api/v1/reportbacks');
```

Next steps include:
- [ ] adding some functionality so that we can nab ENV info from a projects `.env` file and set that as the `baseURL` for each service specific module.
- [ ] update the README for better usage instructions!