### PR TITLE
Adding useful methods to the Phoenix api client class.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "start": "webpack & babel src --watch --out-dir=lib",
-    "build": "NODE_ENV=production webpack && babel src --out-dir lib",
+    "build": "NODE_ENV=production webpack && babel src --out-dir=lib",
     "prepublish": "npm run build"
   },
   "author": "Diego Lorenzo <dlorenzo@dosomething.org>",

--- a/src/Phoenix.js
+++ b/src/Phoenix.js
@@ -1,16 +1,71 @@
 import RestApiClient from './RestApiClient';
 
+/**
+ * Phoenix Client.
+ */
 class Phoenix extends RestApiClient {
+  /**
+   * Client constructor
+   *
+   * @param  {Object} config
+   * @param  {Object} overrides
+   * @return {Object}
+   */
   constructor(config = {}, overrides = {}) {
-    super();
+
+    const url = config.url || null;
+
+    super(url, overrides);
   }
 
-  getAllReportbacks() {
-    // add code to request all reportbacks for a campaign
+  /**
+   * Get an index of (optionally filtered) campaign reportbacks.
+   *
+   * @param  {Object} query
+   * @return {Promise}
+   */
+  getAllReportbacks(query = {}) {
+    return this.get('api/v1/reportbacks', query);
   }
 
-  getReportback() {
-    // add code to request a specific reportback
+  /**
+   * Get details for a particular reportback.
+   *
+   * @param  {Integer} id
+   * @return {Promise}
+   */
+  getReportback(id) {
+    return this.get(`api/v1/reportbacks/${id}`);
+  }
+
+  /**
+   * Get an index of (optionally filtered) campaign signups.
+   *
+   * @param  {Object} query
+   * @return {Promise}
+   */
+  getAllSignups(query = {}) {
+    return this.get('api/v1/signups', query);
+  }
+
+  /**
+   * Get details for a particular campaign signup.
+   *
+   * @param  {Integer} id
+   * @return {Promise}
+   */
+  getSignup(id) {
+    return this.get(`api/v1/signups/${id}`);
+  }
+
+  /**
+   * Store a new campaign signup.
+   *
+   * @param  {Object} body
+   * @return {Promise}
+   */
+  storeSignup(body = {}) {
+    return this.post('api/v1/signups', body);
   }
 }
 


### PR DESCRIPTION
This PR expands on the `Phoenix` api client class to add helper methods that match up with the corresponding API calls to Phoenix (next).

Usage:

```javascript
// filename.js

import { Phoenix } from '@dosomething/gateway';

const phoenixClient = new Phoenix();

phoenixClient.getAllReportbacks()
  .then((response) => {
    doSomethingWith(response);
  });

phoenixClient.getReportback(10)
  .then((response) => {
    doSomethingWith(response);
  });

phoenixClient.getAllSignups()
  .then((response) => {
    doSomethingWith(response);
  });

phoenixClient.getSignup(4269)
  .then((response) => {
    doSomethingWith(response);
  });

phoenixClient.storeSignup({
  user_id: '1600000',
  campaign_id: '1454',
  source: 'phoenix-next'
})
  .then((response) => {
    doSomethingWith(response);
  });
```

_NOTE:_ There seems to be something wonky going on with the Phoenix Legacy `/signups` endpoint when trying to post and store a signup. Something we need to look into...