### PR TITLE
URLs, URLs, URLs!

### DIFF
--- a/src/RestApiClient.js
+++ b/src/RestApiClient.js
@@ -145,12 +145,16 @@ class RestApiClient {
     merge(options, data);
 
     // Developer Output:
-    console.log('%c API Client %s Request:',
+    console.groupCollapsed('%c Gateway: %c %s %s %s',
       'background-color: rgba(105,157,215,0.5); color: rgba(33,70,112,1); display: block; font-weight: bold; line-height: 1.5;',
-      method
+      'background-color: transparent; color: black; font-weight: bold; line-height: 1.5;',
+      method,
+      url.host,
+      url.pathname
     );
-    console.log('Options: \n%o', options);
     console.log('URL: %s', url.toString());
+    console.log('Options:', options);
+    console.groupEnd();
 
     return window.fetch(url, options)
       .then(this.checkStatus)

--- a/src/RestApiClient.js
+++ b/src/RestApiClient.js
@@ -1,13 +1,12 @@
 import merge from 'lodash/merge';
 
 class RestApiClient {
-  constructor(url, overrides = {}) {
-
-    if (!url) {
-      this.url = this.getLocalUrl();
-    } else {
-      this.url = url;
+  constructor(baseUrl, overrides = {}) {
+    if (!baseUrl) {
+      baseUrl = window.location.origin;
     }
+
+    this.baseUrl = new URL(baseUrl);
 
     this.config = {
       headers: {
@@ -52,7 +51,7 @@ class RestApiClient {
    * @return {Object}
    */
   delete(path) {
-    const url = `${this.url}/${path}`;
+    const url = new URL(path, this.baseUrl);
 
     return this.send('DELETE', url);
   }
@@ -69,16 +68,6 @@ class RestApiClient {
   }
 
   /**
-   * Get the local domain url.
-   *
-   * @return {String}
-   */
-  getLocalUrl() {
-    const port = window.location.port ? `:${window.location.port}` : '';
-    return `//${window.location.hostname}${port}`;
-  }
-
-  /**
    * Send a GET request to the given path URI.
    *
    * @param  {String} path
@@ -86,7 +75,8 @@ class RestApiClient {
    * @return {Object}
    */
   get(path, query = {}) {
-    const url = `${this.url}/${path}${this.stringifyQuery(query)}`;
+    const url = new URL(path, this.baseUrl);
+    url.search = this.stringifyQuery(query);
 
     return this.send('GET', url);
   }
@@ -110,7 +100,7 @@ class RestApiClient {
    * @return {Object}
    */
   post(path, body = {}) {
-    const url = `${this.url}/${path}`;
+    const url = new URL(path, this.baseUrl);
 
     return this.send('POST', url, {
       body: JSON.stringify(body)
@@ -159,8 +149,8 @@ class RestApiClient {
       'background-color: rgba(105,157,215,0.5); color: rgba(33,70,112,1); display: block; font-weight: bold; line-height: 1.5;',
       method
     );
-    console.log('URL: \n%s', url);
     console.log('Options: \n%o', options);
+    console.log('URL: %s', url.toString());
 
     return window.fetch(url, options)
       .then(this.checkStatus)


### PR DESCRIPTION
Three more little tweaks while I'm in here:

🌎 Uses the [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL) constructor so we can modify the URL programmatically, rather than using string concatenation.

⚓️ Uses `window.navigator.origin` to grab the default base URL, which avoids the need to worry about string concatenation with the port.

🌳 Collapse details in the logs so it doesn't take as much space:

<img width="714" alt="screen shot 2017-03-03 at 1 44 34 pm" src="https://cloud.githubusercontent.com/assets/583202/23564157/8f4d61b2-0017-11e7-8d33-024781a5fd78.png">
