### PR TITLE
adds logic for queries in filters like filter[status]=pending

### DIFF
--- a/src/RestApiClient.js
+++ b/src/RestApiClient.js
@@ -129,23 +129,22 @@ class RestApiClient {
    * @param  {Object} query
    * @return {String}
    */
-  stringifyQuery(query = {}) {
-    let urlParams = [];
+  stringifyQuery(params = {}, prefix) {
+    const query = Object.keys(params).map((key) => {
+      const value  = params[key];
 
-    Object.keys(query).forEach((key) => {
-      if (key === 'filter') {
-        var filterObj = query[key];
-        urlParams.push(encodeURIComponent(key) + '[' + Object.keys(filterObj) + ']' + '=' + filterObj[Object.keys(filterObj)[0]]);
-      } else {
-        urlParams.push(encodeURIComponent(key) + '=' + encodeURIComponent(query[key]));
-      }
+      if (params.constructor === Array)
+        key = `${prefix}[]`;
+      else if (params.constructor === Object)
+        key = (prefix ? `${prefix}[${key}]` : key);
+
+      if (typeof value === 'object')
+        return stringifyQuery(value, key);
+      else
+        return `${key}=${encodeURIComponent(value)}`;
     });
 
-    if (urlParams.length === 0) {
-      return '';
-    }
-
-    return `?${urlParams.join('&')}`;
+    return [].concat.apply([], query).join('&');
   }
 
   /**

--- a/src/RestApiClient.js
+++ b/src/RestApiClient.js
@@ -128,6 +128,7 @@ class RestApiClient {
    *
    * @param  {Object} query
    * @return {String}
+   * Uses code from https://stackoverflow.com/a/42604801/4422345 for this function.
    */
   stringifyQuery(params = {}, prefix) {
     const query = Object.keys(params).map((key) => {

--- a/src/RestApiClient.js
+++ b/src/RestApiClient.js
@@ -133,7 +133,12 @@ class RestApiClient {
     let urlParams = [];
 
     Object.keys(query).forEach((key) => {
-      urlParams.push(`${encodeURIComponent(key)}=${encodeURIComponent(query[key])}`);
+      if (key === 'filter') {
+        var filterObj = query[key];
+        urlParams.push(encodeURIComponent(key) + '[' + Object.keys(filterObj) + ']' + '=' + filterObj[Object.keys(filterObj)[0]]);
+      } else {
+        urlParams.push(encodeURIComponent(key) + '=' + encodeURIComponent(query[key]));
+      }
     });
 
     if (urlParams.length === 0) {

--- a/src/RestApiClient.js
+++ b/src/RestApiClient.js
@@ -128,7 +128,7 @@ class RestApiClient {
    *
    * @param  {Object} query
    * @return {String}
-   * Uses code from https://stackoverflow.com/a/42604801/4422345 for this function.
+   * @see https://stackoverflow.com/a/42604801/4422345 for where this code was taken from.
    */
   stringifyQuery(params = {}, prefix) {
     const query = Object.keys(params).map((key) => {


### PR DESCRIPTION
Updates `stringifyQuery` to correctly stringify queries that use `filter` (e.g. Rogue's `GET /reportbacks?filter[status]=accepted`.