### PR TITLE
Allows passing query string in URL in GET request

### DIFF
--- a/src/RestApiClient.js
+++ b/src/RestApiClient.js
@@ -77,7 +77,10 @@ class RestApiClient {
    */
   get(path, query = {}) {
     const url = new URL(path, this.baseUrl);
-    url.search = stringifyQuery(query);
+
+    if (query && typeof query === 'object') {
+      url.search = stringifyQuery(query);
+    }
 
     return this.send('GET', url);
   }


### PR DESCRIPTION
In Rogue, we grab the "next" url page for pagination from the API response. This URL has the query params in the string (e.g. `/posts?filter%5Bstatus%5D=accepted&filter%5Bcampaign_id%5D=1173&include=signup%2Csiblings&page=2`). Instead of breaking down this string and formatting the query string in the format gateway-js's `get` expects, we allow to just pass the URL with the query string to `send`. 

We need this because otherwise it tried to `stringifyQuery` on the already stringified query and just returned response from `/posts`.

This is needed in order to merge [this PR](https://github.com/DoSomething/rogue/pull/387) in Rogue.
