### PR TITLE
fixes query bug

### DIFF
--- a/src/RestApiClient.js
+++ b/src/RestApiClient.js
@@ -80,6 +80,8 @@ class RestApiClient {
 
     if (query && typeof query === 'object') {
       url.search = stringifyQuery(query);
+    } else {
+      url.search = query;
     }
 
     return this.send('GET', url);

--- a/src/RestApiClient.js
+++ b/src/RestApiClient.js
@@ -79,10 +79,10 @@ class RestApiClient {
     const url = new URL(path, this.baseUrl);
 
     if (query && typeof query === 'object') {
-      url.search = stringifyQuery(query);
-    } else {
-      url.search = query;
+      query = stringifyQuery(query);
     }
+
+    url.search = query;
 
     return this.send('GET', url);
   }


### PR DESCRIPTION
Adds missing `url.search` if the query is not an object in the `get` function. See [this comment](https://github.com/DoSomething/gateway-js/pull/12/files#r135314619) for more details!