### PR TITLE
Removes `action` property sent by default in all posts

### DIFF
--- a/server/src/endpoints/rogue/posts.js
+++ b/server/src/endpoints/rogue/posts.js
@@ -54,12 +54,6 @@ class RogueEndpointPosts extends OAuthEndpoint {
         request.field(key, data[key]);
       }
     });
-    /**
-     * In the future, Rogue is implementing the concept of actions, for now this
-     * is the expected action.
-     * TODO: Remove when apps start sending their custom "action" property
-     */
-    request.field('action', 'default');
     return request.then(res => res.body);
   }
   // End of "Private" methods --------------------


### PR DESCRIPTION
## What's this PR do?

Now that Gambit will start relaying the proper `action_id` or default to `action: 'default'`. We don't need the Rogue endpoint in the Gateway-js module to send the `action` attribute.

## Relevant issues

[Rogue PR Discussion](https://github.com/DoSomething/rogue/pull/837#discussion_r261369285)