### PR TITLE
Ensure fetch(url) is sent as a string.

### DIFF
--- a/src/RestApiClient.js
+++ b/src/RestApiClient.js
@@ -147,7 +147,7 @@ class RestApiClient {
    * Send an API request using fetch() and return response.
    *
    * @param  {String} method
-   * @param  {String} url
+   * @param  {String|URL} url
    * @param  {Object} data
    * @return {Promise}
    */
@@ -162,7 +162,11 @@ class RestApiClient {
 
     gatewayLog(method, url, options);
 
-    return window.fetch(url, options)
+    // Ensure this is a string before we call fetch() so we don't end up in a
+    // kerfuffle with static typing. <https://stackoverflow.com/a/49980218>
+    const href = url instanceof URL ? url.toString() : url;
+
+    return window.fetch(href, options)
       .then(this.checkStatus)
       .then(this.parseJson)
       .catch((error) => {


### PR DESCRIPTION
We use the `URL` constructor in our helpers as an easy & safe way to modify URLs (e.g. `new URL(path, this.baseUrl)`), but the `fetch` API doesn't _actually_ accept a `URL` to this parameter. In order to avoid [issues with static typing](https://stackoverflow.com/a/49980218) or [tooling that wraps this function](https://github.com/tgriesser/cypress-graphql-mock), let's make sure this is a string.