### PR TITLE
Adds getByEmail and getByUser

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,5 +12,5 @@ DS_NORTHSTAR_API_OAUTH_SCOPES="admin activity write"
 ## Endpoints
 ##
 
-DS_NORTHSTAR_API_BASEURI=https://identity-dev.dosomething.org/api/v2
+DS_NORTHSTAR_API_BASEURI=https://identity-dev.dosomething.org
 DS_ROGUE_API_BASEURI=https://activity-dev.dosomething.org/api/v3

--- a/server/src/endpoints/northstar/endpoint.js
+++ b/server/src/endpoints/northstar/endpoint.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const OAuthEndpoint = require('../oauth-endpoint');
+
+class NorthstarEndpoint extends OAuthEndpoint {
+  constructor(client) {
+    super(client);
+
+    this.baseUri = this.client.config.services.northstar.baseUri;
+  }
+}
+
+
+module.exports = NorthstarEndpoint;

--- a/server/src/endpoints/northstar/users.js
+++ b/server/src/endpoints/northstar/users.js
@@ -17,6 +17,11 @@ class NorthstarEndpointUsers extends OAuthEndpoint {
    */
   get(id, query) { return this.executeGet(`${this.url}/${id}`, query); }
   /**
+   * @param  {String} email
+   * @return {Promise}
+   */
+  getByEmail(email) { return this.executeGet(`${this.url}/email/${email}`); }
+  /**
    * @param  {Object} data
    * @return {Promise}
    */

--- a/server/src/endpoints/northstar/users.js
+++ b/server/src/endpoints/northstar/users.js
@@ -1,42 +1,43 @@
 'use strict';
 
-const OAuthEndpoint = require('../oauth-endpoint');
+const NorthstarEndpoint = require('./endpoint');
 
 /**
  * @see https://github.com/DoSomething/northstar/blob/master/documentation/endpoints/v2/users.md
  */
-class NorthstarEndpointUsers extends OAuthEndpoint {
+class UsersNorthstarEndpoint extends NorthstarEndpoint {
   constructor(client) {
     super(client);
-    this.url = `${this.client.config.services.northstar.baseUri}/users`;
+
+    this.baseUri = `${this.baseUri}/v2`;
   }
   /**
    * @param  {String} id
    * @param  {Object} query
    * @return {Promise}
    */
-  get(id, query) { return this.executeGet(`${this.url}/${id}`, query); }
+  get(id, query) { return this.executeGet(`${this.baseUri}/users/${id}`, query); }
   /**
    * @param  {String} email
    * @return {Promise}
    */
-  getByEmail(email) { return this.executeGet(`${this.url}/email/${email}`); }
+  getByEmail(email) { return this.executeGet(`${this.baseUri}/email/${email}`); }
   /**
    * @param  {String} mobile
    * @return {Promise}
    */
-  getByMobile(mobile) { return this.executeGet(`${this.url}/mobile/${mobile}`); }
+  getByMobile(mobile) { return this.executeGet(`${this.baseUri}/mobile/${mobile}`); }
   /**
    * @param  {Object} data
    * @return {Promise}
    */
-  create(data) { return this.executePost(this.url, data); }
+  create(data) { return this.executePost(`${this.baseUri}/users`, data); }
   /**
    * @param  {String} id
    * @param  {Object} data
    * @return {Promise}
    */
-  update(id, data) { return this.executePost(`${this.url}/${id}`, data); }
+  update(id, data) { return this.executePost(`${this.baseUri}/users/${id}`, data); }
 }
 
-module.exports = NorthstarEndpointUsers;
+module.exports = UsersNorthstarEndpoint;

--- a/server/src/endpoints/northstar/users.js
+++ b/server/src/endpoints/northstar/users.js
@@ -22,6 +22,11 @@ class NorthstarEndpointUsers extends OAuthEndpoint {
    */
   getByEmail(email) { return this.executeGet(`${this.url}/email/${email}`); }
   /**
+   * @param  {String} mobile
+   * @return {Promise}
+   */
+  getByMobile(mobile) { return this.executeGet(`${this.url}/mobile/${mobile}`); }
+  /**
    * @param  {Object} data
    * @return {Promise}
    */


### PR DESCRIPTION
This PR adds new methods to the `NorthstarEndpointUsers` class to execute Northstar's `GET /v2/email/:email` and `GET /v2/mobile/:mobile` API requests. These will be used in Gambit and [Gambit Slack](https://github.com/DoSomething/gambit-slack/pull/53/) to eventually deprecate the Northstar `/v1/users` API endpoint (I believe these two apps are the only the ones that still query it?)