### PR TITLE
Fixes 405 error for updating user

### DIFF
--- a/server/src/endpoints/northstar/users.js
+++ b/server/src/endpoints/northstar/users.js
@@ -37,7 +37,7 @@ class UsersNorthstarEndpoint extends NorthstarEndpoint {
    * @param  {Object} data
    * @return {Promise}
    */
-  update(id, data) { return this.executePost(`${this.baseUri}/users/${id}`, data); }
+  update(id, data) { return this.executePut(`${this.baseUri}/users/${id}`, data); }
 }
 
 module.exports = UsersNorthstarEndpoint;

--- a/server/src/endpoints/oauth-endpoint.js
+++ b/server/src/endpoints/oauth-endpoint.js
@@ -19,6 +19,7 @@ class OAuthEndpoint {
       .query(query)
       .then(res => res.body);
   }
+
   /**
    * executePost - sends POST requests to a service with OAuth authentication
    *
@@ -30,6 +31,22 @@ class OAuthEndpoint {
     return this.client
       .request('clientCredentials')
       .post(url)
+      .accept('json')
+      .send(data)
+      .then(res => res.body);
+  }
+
+  /**
+   * executePut - sends PUT requests to a service with OAuth authentication
+   *
+   * @param  {string} url
+   * @param  {Object} data
+   * @return {Promise}
+   */
+  executePut(url, data) {
+    return this.client
+      .request('clientCredentials')
+      .put(url)
       .accept('json')
       .send(data)
       .then(res => res.body);


### PR DESCRIPTION
Gambit Slack doesn't make any update user requests. Now that I'm working on similar changes in our Gambit project, I realized I didn't catch that the `Users.update` method throws a 405: `The POST method is not supported for this route. Supported methods: GET, HEAD, PUT, PATCH, DELETE."`