### PR TITLE
Adds Users.index, support for query parameters when finding by email or mobile

### DIFF
--- a/server/src/endpoints/northstar/users.js
+++ b/server/src/endpoints/northstar/users.js
@@ -19,19 +19,26 @@ class UsersNorthstarEndpoint extends NorthstarEndpoint {
   get(id, query) { return this.executeGet(`${this.baseUri}/users/${id}`, query); }
   /**
    * @param  {String} email
+   * @param  {Object} query
    * @return {Promise}
    */
-  getByEmail(email) { return this.executeGet(`${this.baseUri}/email/${email}`); }
+  getByEmail(email, query) { return this.executeGet(`${this.baseUri}/email/${email}`, query); }
   /**
    * @param  {String} mobile
+   * @param  {Object} query
    * @return {Promise}
    */
-  getByMobile(mobile) { return this.executeGet(`${this.baseUri}/mobile/${mobile}`); }
+  getByMobile(mobile) { return this.executeGet(`${this.baseUri}/mobile/${mobile}`, query); }
   /**
    * @param  {Object} data
    * @return {Promise}
    */
   create(data) { return this.executePost(`${this.baseUri}/users`, data); }
+  /**
+   * @param  {Object} query
+   * @return {Promise}
+   */
+  index(query) { return this.executeGet(`${this.baseUri}/users`, query); }
   /**
    * @param  {String} id
    * @param  {Object} data


### PR DESCRIPTION
This PR adds a `Users.index` method to execute a `GET /users` index query, and adds support to pass an optional `query` object parameter to `Users.getByEmail` and `Users.getByMobile`. 

Refs https://github.com/DoSomething/gambit-slack/pull/54